### PR TITLE
Allow compatibility with Rotations.jl v1.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,12 +3,12 @@ uuid = "150eb455-5306-5404-9cee-2592286d6298"
 version = "0.5.1"
 
 [deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-Rotations = "0.10,0.11,0.12,0.13"
+Rotations = "0.10,0.11,0.12,0.13, 1"
 StaticArrays = "0.11,0.12"
 julia = "1"
 

--- a/src/CoordinateTransformations.jl
+++ b/src/CoordinateTransformations.jl
@@ -4,11 +4,21 @@ using StaticArrays
 using LinearAlgebra
 
 using Rotations
-export RotMatrix, Quat, SpQuat, AngleAxis, RodriguesVec,
+
+# Re-export useful rotation types from Rotations.jl
+export RotMatrix, AngleAxis,
        RotX, RotY, RotZ,
        RotXY, RotYX, RotZX, RotXZ, RotYZ, RotZY,
        RotXYX, RotYXY, RotZXZ, RotXZX, RotYZY, RotZYZ,
        RotXYZ, RotYXZ, RotZXY, RotXZY, RotYZX, RotZYX
+
+# Export quaternion and rotation vector types for Rotations.jl < v1.0
+# Note: it's ok to have these `export` commands even for later versions
+# of Rotations.jl`. Doing `export foo` is allowed when `foo` is undefined.
+export Quat, SpQuat, RodriguesVec
+
+# Export quaternion and rotation vector types for Rotations.jl 1.0
+export UnitQuaternion, MRP, RotationVector
 
 # Core methods
 export compose, ∘, transform_deriv, transform_deriv_params, recenter


### PR DESCRIPTION
This PR adds compatibility with Rotations.jl v1.x. The changes turned out to be trivial: there's just one place where this package re-exports some Rotations.jl types, so we need to handle the new types there. 