### PR TITLE
Add CompatHelper

### DIFF
--- a/.github/workflows/compathelper.yml
+++ b/.github/workflows/compathelper.yml
@@ -1,0 +1,17 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: '00 00 * * *'
+
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/compathelper.yml
+++ b/.github/workflows/compathelper.yml
@@ -13,5 +13,5 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
Note that with the default settings, CI will not be triggered on CompatHelper PRs. As explained [here](https://github.com/bcbi/CompatHelper.jl#12-set-up-the-ssh-deploy-key-optional) ssh deploy keys would be required for that.