### PR TITLE
add Polard type

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ The package accepts any `AbstractVector` type for Cartesian coordinates (as
 well as *FixedSizeArrays* types in Julia v0.4 only). For speed, we recommend
 using a statically-sized container such as `SVector{N}` from *StaticArrays*.
 
-We do provide a few specialist coordinate types. The `Polar(r, θ)` type is a 2D
-polar representation of a point, and similarly in 3D we have defined
+We do provide a few specialist coordinate types. The `Polar(r, θ)` and `Polard(r, θ)` types are 2D
+polar representations of a point (using radians and degrees, respectively). In 3D we have defined
 `Spherical(r, θ, ϕ)` and `Cylindrical(r, θ, z)`.
 
 #### Coordinate system transformations
@@ -122,7 +122,8 @@ Two-dimensional coordinates may be converted using these parameterless (singleto
 transformations:
 
 1. `PolarFromCartesian()`
-2. `CartesianFromPolar()`
+2. `PolardFromCartesian()`
+3. `CartesianFromPolar()`
 
 Three-dimensional coordinates may be converted using these parameterless
 transformations:

--- a/src/CoordinateTransformations.jl
+++ b/src/CoordinateTransformations.jl
@@ -9,7 +9,7 @@ export Transformation, IdentityTransformation
 
 # 2D coordinate systems and their transformations
 export Polar, Polard
-export PolarFromCartesian, CartesianFromPolar
+export PolarFromCartesian, PolardFromCartesian, CartesianFromPolar
 
 # 3D coordinate systems and their transformations
 export Spherical, Cylindrical

--- a/src/CoordinateTransformations.jl
+++ b/src/CoordinateTransformations.jl
@@ -8,7 +8,7 @@ export compose, ∘, transform_deriv, transform_deriv_params, recenter
 export Transformation, IdentityTransformation
 
 # 2D coordinate systems and their transformations
-export Polar
+export Polar, Polard
 export PolarFromCartesian, CartesianFromPolar
 
 # 3D coordinate systems and their transformations

--- a/src/coordinatesystems.jl
+++ b/src/coordinatesystems.jl
@@ -50,13 +50,11 @@ Base.show(io::IO, x::Polard) = print(io, "Polard(r=$(x.r), θ=$(x.θ)°)")
 @inline Base.convert(::Type{Polard}, p::Polar) = Polard(p.r, rad2deg(angle(p)))
 
 
-"""
-`PolarFromCartesian()` - transformation from `AbstractVector` of length 2 to `Polar` type
-`PolarFromCartesian{Polar}()` - transformation from `AbstractVector` of length 2 to `Polar` type
-`PolarFromCartesian{Polard}()` - transformation from `AbstractVector` of length 2 to `Polar` type
-"""
+"`PolarFromCartesian()` - transformation from `AbstractVector` of length 2 to `Polar` type"
 struct PolarFromCartesian{PT<:PolarType} <: Transformation; end
 PolarFromCartesian() = PolarFromCartesian{Polar}() # default is Polar
+"`PolardFromCartesian()` - transformation from `AbstractVector` of length 2 to `Polar` type"
+const PolardFromCartesian = PolarFromCartesian{Polard}
 
 "`CartesianFromPolar()` - transformation from `Polar` or `Polard` type to `SVector{2}` type"
 struct CartesianFromPolar <: Transformation; end

--- a/src/coordinatesystems.jl
+++ b/src/coordinatesystems.jl
@@ -1,10 +1,12 @@
 #############################
 ### 2D Coordinate systems ###
 #############################
+abstract type PolarType end
+
 """
 `Polar{T,A}(r::T, θ::A)` - 2D polar coordinates
 """
-struct Polar{T,A}
+struct Polar{T,A} <: PolarType
     r::T
     θ::A
 
@@ -17,44 +19,93 @@ function Polar(r, θ)
     return Polar{typeof(r2), typeof(θ2)}(r2, θ2)
 end
 
-Base.show(io::IO, x::Polar) = print(io, "Polar(r=$(x.r), θ=$(x.θ) rad)")
-Base.isapprox(p1::Polar, p2::Polar; kwargs...) = isapprox(p1.r, p2.r; kwargs...) && isapprox(p1.θ, p2.θ; kwargs...)
+# get angle in radians
+angle(x::Polar) = x.θ
 
-"`PolarFromCartesian()` - transformation from `AbstractVector` of length 2 to `Polar` type"
-struct PolarFromCartesian <: Transformation; end
+Base.show(io::IO, x::Polar) = print(io, "Polar(r=$(x.r), θ=$(x.θ) rad)")
+Base.isapprox(p1::PolarType, p2::PolarType; kwargs...) = isapprox(p1.r, p2.r; kwargs...) && isapprox(angle(p1), angle(p2); kwargs...)
+
+"""
+`Polard{T,A}(r::T, θ::A)` - 2D polar coordinates (using degrees)
+"""
+struct Polard{T,A} <: PolarType
+    r::T
+    θ::A
+
+    Polard{T, A}(r, θ) where {T, A} = new(r, θ)
+end
+
+function Polard(r, θ)
+    r2, θ2 = promote(r, θ)
+
+    return Polard{typeof(r2), typeof(θ2)}(r2, θ2)
+end
+
+# get angle in radians
+angle(x::Polard) = deg2rad(x.θ)
+
+Base.show(io::IO, x::Polard) = print(io, "Polard(r=$(x.r), θ=$(x.θ)°)")
+
+@inline Base.convert(::Type{Polar}, p::PolarType) = Polar(p.r, angle(p))
+@inline Base.convert(::Type{Polard}, p::PolarType) = Polard(p.r, rad2deg(angle(p)))
+
+
+"""
+`PolarFromCartesian()` - transformation from `AbstractVector` of length 2 to `Polar` type
+`PolarFromCartesian{Polar}()` - transformation from `AbstractVector` of length 2 to `Polar` type
+`PolarFromCartesian{Polard}()` - transformation from `AbstractVector` of length 2 to `Polar` type
+"""
+struct PolarFromCartesian{PT<:PolarType} <: Transformation; end
+PolarFromCartesian() = PolarFromCartesian{Polar}() # default is Polar
+
 "`CartesianFromPolar()` - transformation from `Polar` type to `SVector{2}` type"
 struct CartesianFromPolar <: Transformation; end
 
-Base.show(io::IO, trans::PolarFromCartesian) = print(io, "PolarFromCartesian()")
+Base.show(io::IO, trans::PolarFromCartesian{P}) where {P} = print(io, "PolarFromCartesian{$P}()")
 Base.show(io::IO, trans::CartesianFromPolar) = print(io, "CartesianFromPolar()")
 
-function (::PolarFromCartesian)(x::AbstractVector)
+function (::PolarFromCartesian{Polar})(x::AbstractVector)
     length(x) == 2 || error("Polar transform takes a 2D coordinate")
 
     Polar(hypot(x[1], x[2]), atan(x[2], x[1]))
 end
 
-function transform_deriv(::PolarFromCartesian, x::AbstractVector)
+function (::PolarFromCartesian{Polard})(x::AbstractVector)
+    length(x) == 2 || error("Polar transform takes a 2D coordinate")
+
+    Polard(hypot(x[1], x[2]), rad2deg(atan(x[2], x[1])))
+end
+
+function transform_deriv(::PolarFromCartesian{Polar}, x::AbstractVector{T}) where {T}
     length(x) == 2 || error("Polar transform takes a 2D coordinate")
 
     r = hypot(x[1], x[2])
     f = x[2] / x[1]
-    c = one(eltype(x))/(x[1]*(one(eltype(x)) + f*f))
+    c = one(T)/(x[1]*(one(T) + f*f))
+    @SMatrix [ x[1]/r    x[2]/r ;
+              -f*c       c      ]
+end
+function transform_deriv(::PolarFromCartesian{Polard}, x::AbstractVector{T}) where {T}
+    length(x) == 2 || error("Polard transform takes a 2D coordinate")
+
+    r = hypot(x[1], x[2])
+    f = x[2] / x[1]
+    c = rad2deg(one(T))/(x[1]*(one(T) + f*f))
     @SMatrix [ x[1]/r    x[2]/r ;
               -f*c       c      ]
 end
 transform_deriv_params(::PolarFromCartesian, x::AbstractVector) = error("PolarFromCartesian has no parameters")
 
-function (::CartesianFromPolar)(x::Polar)
-    s,c = sincos(x.θ)
+function (::CartesianFromPolar)(x::PolarType)
+    s,c = sincos(angle(x))
     SVector(x.r * c, x.r * s)
 end
-function transform_deriv(::CartesianFromPolar, x::Polar)
-    sθ, cθ = sincos(x.θ)
+function transform_deriv(::CartesianFromPolar, x::PolarType)
+    sθ, cθ = sincos(angle(x))
     @SMatrix [cθ  -x.r*sθ ;
               sθ   x.r*cθ ]
 end
-transform_deriv_params(::CartesianFromPolar, x::Polar) = error("CartesianFromPolar has no parameters")
+transform_deriv_params(::CartesianFromPolar, x::PolarType) = error("CartesianFromPolar has no parameters")
 
 Base.inv(::PolarFromCartesian) = CartesianFromPolar()
 Base.inv(::CartesianFromPolar) = PolarFromCartesian()
@@ -63,10 +114,9 @@ compose(::PolarFromCartesian, ::CartesianFromPolar) = IdentityTransformation()
 compose(::CartesianFromPolar, ::PolarFromCartesian) = IdentityTransformation()
 
 # For convenience
-Base.convert(::Type{Polar}, v::AbstractVector) = PolarFromCartesian()(v)
-@inline Base.convert(::Type{V}, p::Polar) where {V <: AbstractVector} = convert(V, CartesianFromPolar()(p))
-@inline Base.convert(::Type{V}, p::Polar) where {V <: StaticVector} = convert(V, CartesianFromPolar()(p))
-
+Base.convert(::Type{PT}, v::AbstractVector) where {PT<:PolarType} = PolarFromCartesian{PT}()(v)
+@inline Base.convert(::Type{V}, p::PolarType) where {V <: AbstractVector} = convert(V, CartesianFromPolar()(p))
+@inline Base.convert(::Type{V}, p::PolarType) where {V <: StaticVector} = convert(V, CartesianFromPolar()(p))
 
 #############################
 ### 3D Coordinate Systems ###

--- a/src/coordinatesystems.jl
+++ b/src/coordinatesystems.jl
@@ -100,10 +100,16 @@ function (::CartesianFromPolar)(x::PolarType)
     s,c = sincos(angle(x))
     SVector(x.r * c, x.r * s)
 end
-function transform_deriv(::CartesianFromPolar, x::PolarType)
+function transform_deriv(::CartesianFromPolar, x::Polar)
     sθ, cθ = sincos(angle(x))
     @SMatrix [cθ  -x.r*sθ ;
               sθ   x.r*cθ ]
+end
+function transform_deriv(::CartesianFromPolar, x::Polard)
+    sθ, cθ = sincos(angle(x))
+    a = rad2deg(x.r)
+    @SMatrix [cθ  -a*sθ ;
+              sθ   a*cθ ]
 end
 transform_deriv_params(::CartesianFromPolar, x::PolarType) = error("CartesianFromPolar has no parameters")
 

--- a/src/coordinatesystems.jl
+++ b/src/coordinatesystems.jl
@@ -47,7 +47,7 @@ angle(x::Polard) = deg2rad(x.θ)
 Base.show(io::IO, x::Polard) = print(io, "Polard(r=$(x.r), θ=$(x.θ)°)")
 
 @inline Base.convert(::Type{Polar}, p::PolarType) = Polar(p.r, angle(p))
-@inline Base.convert(::Type{Polard}, p::PolarType) = Polard(p.r, rad2deg(angle(p)))
+@inline Base.convert(::Type{Polard}, p::Polar) = Polard(p.r, rad2deg(angle(p)))
 
 
 """
@@ -58,7 +58,7 @@ Base.show(io::IO, x::Polard) = print(io, "Polard(r=$(x.r), θ=$(x.θ)°)")
 struct PolarFromCartesian{PT<:PolarType} <: Transformation; end
 PolarFromCartesian() = PolarFromCartesian{Polar}() # default is Polar
 
-"`CartesianFromPolar()` - transformation from `Polar` type to `SVector{2}` type"
+"`CartesianFromPolar()` - transformation from `Polar` or `Polard` type to `SVector{2}` type"
 struct CartesianFromPolar <: Transformation; end
 
 Base.show(io::IO, trans::PolarFromCartesian{P}) where {P} = print(io, "PolarFromCartesian{$P}()")
@@ -71,7 +71,7 @@ function (::PolarFromCartesian{Polar})(x::AbstractVector)
 end
 
 function (::PolarFromCartesian{Polard})(x::AbstractVector)
-    length(x) == 2 || error("Polar transform takes a 2D coordinate")
+    length(x) == 2 || error("Polard transform takes a 2D coordinate")
 
     Polard(hypot(x[1], x[2]), rad2deg(atan(x[2], x[1])))
 end
@@ -81,7 +81,7 @@ function transform_deriv(::PolarFromCartesian{Polar}, x::AbstractVector{T}) wher
 
     r = hypot(x[1], x[2])
     f = x[2] / x[1]
-    c = one(T)/(x[1]*(one(T) + f*f))
+    c = one(T) / (x[1] * (one(T) + f*f))
     @SMatrix [ x[1]/r    x[2]/r ;
               -f*c       c      ]
 end
@@ -90,7 +90,7 @@ function transform_deriv(::PolarFromCartesian{Polard}, x::AbstractVector{T}) whe
 
     r = hypot(x[1], x[2])
     f = x[2] / x[1]
-    c = rad2deg(one(T))/(x[1]*(one(T) + f*f))
+    c = rad2deg(one(T)) / (x[1] * (one(T) + f*f))
     @SMatrix [ x[1]/r    x[2]/r ;
               -f*c       c      ]
 end

--- a/test/coordinatesystems.jl
+++ b/test/coordinatesystems.jl
@@ -16,11 +16,13 @@
         # create dual vector
         xy_gn = SA[Dual(xy[1], (1.0, 0.0)), Dual(xy[2], (0.0, 1.0))]
 
+        # forward transform
         rθ_gn = tform(xy_gn)
         m_gn = gradient(rθ_gn)
         m = transform_deriv(tform, xy)
         @test m ≈ m_gn
 
+        # inverse transform
         rθ_gn = get_PT(rθ)(Dual(rθ.r, (1.0, 0.0)), Dual(rθ.θ, (0.0, 1.0)))
         xy_gn = inv(tform)(rθ_gn)
         m_gn = gradient(xy_gn)
@@ -70,6 +72,7 @@
         @test CoordinateTransformations.angle(rθ) ≈ CoordinateTransformations.angle(rθd)
 
         test_gradient(xy, rθ, p_from_c)
+        # test_gradient(xy, rθd, pd_from_c)
 
 
         # 2nd quadrant
@@ -84,6 +87,7 @@
         @test c_from_p(rθd) ≈ xy
 
         test_gradient(xy, rθ, p_from_c)
+        # test_gradient(xy, rθd, pd_from_c)
 
         # 3rd quadrant
         xy = SVector(1.0, -2.0)
@@ -97,6 +101,7 @@
         @test c_from_p(rθd) ≈ xy
 
         test_gradient(xy, rθ, p_from_c)
+        # test_gradient(xy, rθd, pd_from_c)
 
         # 4th quadrant
         xy = SVector(-1.0, -2.0)
@@ -110,6 +115,7 @@
         @test c_from_p(rθd) ≈ xy
 
         test_gradient(xy, rθ, p_from_c)
+        # test_gradient(xy, rθd, pd_from_c)
 
         @testset "Common types - Polar" begin
             xy = SVector(1.0, 2.0)

--- a/test/coordinatesystems.jl
+++ b/test/coordinatesystems.jl
@@ -34,7 +34,8 @@
         c_from_p = CartesianFromPolar()
         p_from_c = PolarFromCartesian()
         @test p_from_c isa PolarFromCartesian{Polar} # test defaults to Polar
-        pd_from_c = PolarFromCartesian{Polard}()
+        pd_from_c = PolardFromCartesian()
+        @test pd_from_c isa PolarFromCartesian{Polard}
         identity_c = IdentityTransformation()
         identity_p = IdentityTransformation()
 

--- a/test/coordinatesystems.jl
+++ b/test/coordinatesystems.jl
@@ -1,10 +1,10 @@
 @testset "Coordinate Systems" begin
-    function gradient(xy)
+    function jacobian(xy)
         SA[ partials(xy[1], 1) partials(xy[1], 2);
             partials(xy[2], 1) partials(xy[2], 2) ]
     end
 
-    function gradient(rθ::CoordinateTransformations.PolarType)
+    function jacobian(rθ::CoordinateTransformations.PolarType)
         SA[ partials(rθ.r, 1) partials(rθ.r, 2);
             partials(rθ.θ, 1) partials(rθ.θ, 2) ]
     end
@@ -12,20 +12,20 @@
     get_PT(::Polar) = Polar
     get_PT(::Polard) = Polard
 
-    function test_gradient(xy, rθ, tform)
+    function test_jacobian(xy, rθ, tform)
         # create dual vector
         xy_gn = SA[Dual(xy[1], (1.0, 0.0)), Dual(xy[2], (0.0, 1.0))]
 
         # forward transform
         rθ_gn = tform(xy_gn)
-        m_gn = gradient(rθ_gn)
+        m_gn = jacobian(rθ_gn)
         m = transform_deriv(tform, xy)
         @test m ≈ m_gn
 
         # inverse transform
         rθ_gn = get_PT(rθ)(Dual(rθ.r, (1.0, 0.0)), Dual(rθ.θ, (0.0, 1.0)))
         xy_gn = inv(tform)(rθ_gn)
-        m_gn = gradient(xy_gn)
+        m_gn = jacobian(xy_gn)
         m = transform_deriv(inv(tform), rθ)
         @test m ≈ m_gn
     end
@@ -71,8 +71,8 @@
         @test rθ ≈ rθd
         @test CoordinateTransformations.angle(rθ) ≈ CoordinateTransformations.angle(rθd)
 
-        test_gradient(xy, rθ, p_from_c)
-        # test_gradient(xy, rθd, pd_from_c)
+        test_jacobian(xy, rθ, p_from_c)
+        # test_jacobian(xy, rθd, pd_from_c)
 
 
         # 2nd quadrant
@@ -86,8 +86,8 @@
         @test c_from_p(rθ) ≈ xy
         @test c_from_p(rθd) ≈ xy
 
-        test_gradient(xy, rθ, p_from_c)
-        # test_gradient(xy, rθd, pd_from_c)
+        test_jacobian(xy, rθ, p_from_c)
+        # test_jacobian(xy, rθd, pd_from_c)
 
         # 3rd quadrant
         xy = SVector(1.0, -2.0)
@@ -100,8 +100,8 @@
         @test c_from_p(rθ) ≈ xy
         @test c_from_p(rθd) ≈ xy
 
-        test_gradient(xy, rθ, p_from_c)
-        # test_gradient(xy, rθd, pd_from_c)
+        test_jacobian(xy, rθ, p_from_c)
+        # test_jacobian(xy, rθd, pd_from_c)
 
         # 4th quadrant
         xy = SVector(-1.0, -2.0)
@@ -114,8 +114,8 @@
         @test c_from_p(rθ) ≈ xy
         @test c_from_p(rθd) ≈ xy
 
-        test_gradient(xy, rθ, p_from_c)
-        # test_gradient(xy, rθd, pd_from_c)
+        test_jacobian(xy, rθ, p_from_c)
+        # test_jacobian(xy, rθd, pd_from_c)
 
         @testset "Common types - Polar" begin
             xy = SVector(1.0, 2.0)


### PR DESCRIPTION
this adds the `Polard` type which is a polar representation using degrees instead of radians. Internally the angle is stored as a degree and converted to radians internally before calculating conversions.

Internally, this adds an abstract `PolarType` and an `angle` function. Correspondingly `isapprox` has been updated to work with both types and conversion methods have been written for both.

Additionally, I've altered the `PolarFromCartesian` struct to have a type parameter for the polar type. The singletons `PolarFromCartesian()` and `PolardFromCartesian()` dispatch to this and the conversion functions and jacobians have been updated.

Unit tests have been added and I took the liberty of adding some helper functions to tidy up the jacobian testing. I've added a blip in the README and also bumped the version to `0.6.2`.
