### PR TITLE
recenter: accept `origin::Tuple`

### DIFF
--- a/src/affine.jl
+++ b/src/affine.jl
@@ -49,6 +49,7 @@ Base.show(io::IO, trans::LinearMap) = print(io, "LinearMap($(trans.linear))") # 
 function (trans::LinearMap{M})(x) where {M}
     trans.linear * x
 end
+(trans::LinearMap{M})(x::Tuple) where {M} = trans(SVector(x))
 
 Base.inv(trans::LinearMap) = LinearMap(inv(trans.linear))
 
@@ -204,7 +205,7 @@ function Base.:(==)(t1::LinearMap, t2::AffineMap)
         0 == vecnorm(t2.translation)
 end
 
-recenter(trans::AbstractMatrix, origin::AbstractVector) = recenter(LinearMap(trans), origin)
+recenter(trans::AbstractMatrix, origin::Union{AbstractVector, Tuple}) = recenter(LinearMap(trans), origin)
 
 transform_deriv(trans::AffineMap, x) = trans.linear
 # TODO transform_deriv_params

--- a/src/core.jl
+++ b/src/core.jl
@@ -79,7 +79,7 @@ Base.inv(trans::ComposedTransformation) = inv(trans.t2) ∘ inv(trans.t1)
 Base.inv(trans::IdentityTransformation) = trans
 
 """
-    recenter(trans::Union{AbstractMatrix,Transformation}, origin::AbstractVector) -> ctrans
+    recenter(trans::Union{AbstractMatrix,Transformation}, origin::Union{AbstractVector, Tuple}) -> ctrans
 
 Return a new transformation `ctrans` such that point `origin` serves
 as the origin-of-coordinates for `trans`. Translation by `±origin`
@@ -97,6 +97,7 @@ space around `origin`.
 function recenter(trans::Transformation, origin::AbstractVector)
     Translation(origin) ∘ trans ∘ Translation(-origin)
 end
+recenter(trans::Transformation, origin::Tuple) = recenter(trans, SVector(origin))
 
 
 """

--- a/test/affine.jl
+++ b/test/affine.jl
@@ -107,6 +107,13 @@ end
             @test c(origin) == origin
             @test c(zero(origin)) == [6,-6]
         end
+
+        # Tuple is converted to SVector first
+        origin = (5, -3)
+        new_origin = SVector(origin)
+        c = recenter(M, origin)
+        @test c(origin) == new_origin
+        @test c(zero(new_origin)) == [6, -6]
     end
 
     @testset "application of AffineMap in terms of LinearMap and Translation" begin


### PR DESCRIPTION
`OffsetArrays.center` is added in https://github.com/JuliaArrays/OffsetArrays.jl/pull/242, and I think it makes sense to remove `ImageTransformations.center` in favor of `OffsetArrays.center`

```julia
# https://github.com/JuliaImages/ImageTransformations.jl/blob/master/src/ImageTransformations.jl#L43-L44
center(img::AbstractArray{T,N}) where {T,N} = SVector{N}(map(_center, axes(img)))
_center(ind::AbstractUnitRange) = (first(ind)+last(ind))/2
```

The only reason that `SVector` is used here is because `CoordinateTransformations.recenter` requires `AbstractVector` input, I relax this constrain in this PR so that `OffsetArrays.center` can be a drop-in replacement for `ImageTransformations.center` (if we ignore the integer rounding differences).