### PR TITLE
fix docstring typo: `AbstractTransformation` -> `Transformation`

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -119,7 +119,7 @@ end
 
 
 """
-    transform_deriv_params(trans::AbstractTransformation, x)
+    transform_deriv_params(trans::Transformation, x)
 
 A matrix describing how differentials on the parameters of `trans` flow through
 to the output of transformation `trans` given input `x`.


### PR DESCRIPTION
`Transformation` is an abstract type (ref line 15 in core.jl). `AbstractTransformation` does not exist