### PR TITLE
Added convenience Polar() constructor

### DIFF
--- a/src/coordinatesystems.jl
+++ b/src/coordinatesystems.jl
@@ -17,6 +17,13 @@ function Polar(r, θ)
     return Polar{typeof(r2), typeof(θ2)}(r2, θ2)
 end
 
+"""
+`Polar{T,T}(x::AbstractVector)` - 2D polar coordinates from an AbstractVector of length 2
+"""
+function Polar(x::AbstractVector)
+    return PolarFromCartesian()(x)
+end
+
 Base.show(io::IO, x::Polar) = print(io, "Polar(r=$(x.r), θ=$(x.θ) rad)")
 Base.isapprox(p1::Polar, p2::Polar; kwargs...) = isapprox(p1.r, p2.r; kwargs...) && isapprox(p1.θ, p2.θ; kwargs...)
 

--- a/test/coordinatesystems.jl
+++ b/test/coordinatesystems.jl
@@ -127,6 +127,15 @@
             @test p_from_c(collect(xy)) ≈ rθ
             @test c_from_p(rθ) ≈ xy
         end
+
+        @testset "Convenience Polar() constructor" begin
+            @test typeof(Polar(SVector(1.0,2.0))) == typeof(Polar(1.0, 1.0))
+            @test typeof(Polar(SVector(1.0f0,2.0f0))) == typeof(Polar(1.0f0, 1.0f0))
+            @test Polar(SVector(0,2)) ≈ Polar(2,π/2)
+            @test Polar(SVector(1,1)) ≈ Polar(sqrt(2),π/4)
+            @test Polar([1,1]) ≈ Polar(sqrt(2),π/4)
+            @test_throws "Polar transform takes a 2D coordinate" Polar([1,1,1])
+        end
     end
 
     @testset "3D" begin


### PR DESCRIPTION
This adds a simple Polar() convenience constructor that accepts an AbstractVector.
The constructor is mentioned in the README file but doesn't exist. 
This closes issue #83.